### PR TITLE
Fix issue with setting raw mode on tty

### DIFF
--- a/examples/motors.js
+++ b/examples/motors.js
@@ -4,8 +4,8 @@ var max_speed_l = 150;
 var max_speed_r = 140;
 
 // set up the input
-var stdin = process.openStdin();
-require('tty').setRawMode(true);
+var stdin = process.stdin;
+stdin.setRawMode(true);
 
 var board = new five.Board({port: process.argv[2]});
 


### PR DESCRIPTION
Fixing this guy: TypeError: require(...).setRawMode is not a function
    at Object.<anonymous> (/Users/zed/mbot_nodebots/examples/motors.js:8:16)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3